### PR TITLE
feat(dapp-interface): go live at jackblock.network

### DIFF
--- a/modules/interface/package.json
+++ b/modules/interface/package.json
@@ -1,5 +1,6 @@
 {
   "name": "substrate-front-end-template",
+  "homepage": "http://www.jackblock.network.s3-website-ap-southeast-2.amazonaws.com/",
   "version": "0.1.1",
   "private": true,
   "author": "Parity Technologies <admin@parity.io>",
@@ -71,9 +72,8 @@
       "last 1 safari version"
     ]
   },
-  "homepage": "https://substrate-developer-hub.github.io/substrate-front-end-template",
   "bugs": {
-    "url": "https://github.com/substrate-developer-hub/substrate-front-end-template/issues"
+    "url": "https://github.com/korzewski/jackblock/issues"
   },
   "keywords": [
     "substrate",

--- a/modules/interface/src/config/production.json
+++ b/modules/interface/src/config/production.json
@@ -1,3 +1,3 @@
 {
-  "PROVIDER_SOCKET": "wss://dev-node.substrate.dev"
+  "PROVIDER_SOCKET": "wss://ws.jackblock.network"
 }


### PR DESCRIPTION
This PR makes the DAPP interface set up for the S3 bucket (which is set to `www.jackblock.network`) 

![image](https://user-images.githubusercontent.com/3687215/114259132-1906e000-9a0f-11eb-85e7-e3f1653c4f04.png)
